### PR TITLE
Add rejection condition for nested attributes

### DIFF
--- a/app/models/suggestion_box/suggestion.rb
+++ b/app/models/suggestion_box/suggestion.rb
@@ -4,7 +4,7 @@ module SuggestionBox
     acts_as_votable
 
     has_many :photos, class_name: 'SuggestionBox::Photo', dependent: :destroy
-    accepts_nested_attributes_for :photos, allow_destroy: true
+    accepts_nested_attributes_for :photos, allow_destroy: true, reject_if: proc { |attributes| attributes['image'].nil? }
     belongs_to :user, class_name: SuggestionBox.author_class || 'User'
 
     validates_length_of :photos, maximum: 5


### PR DESCRIPTION
Reject nested attributes if 'image' is nil.
This PR fixes error when you try to change status of suggestion with photo.

`PG::NotNullViolation - ERROR:  null value in column "image" violates not-null constraint`
